### PR TITLE
Updated ADO Pipeline to work on PRs and add bug

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,16 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
 
 trigger:
-  branches:
-    include:
-     - master
+  # GitHub only: (Use Branch Policies in ADO to configure which pipeline to execute)
+  pr:
+    - master
   paths:
    include:
     - apis/poi
 
 pool:
   vmImage: 'ubuntu-latest'
+#  vmImage: 'windows-latest'
 
 steps:
 - task: UseDotNet@2
@@ -23,37 +24,63 @@ steps:
   displayName: Restore
   inputs:
     command: restore
+    projects: 'apis/**/**/*.csproj'
 
 - task: DotNetCoreCLI@2
   displayName: Build
   inputs:
     command: build
-    projects: '**/*.csproj'
+    projects: 'apis/**/**/*.csproj'
     arguments: '--configuration Release' # Update this to match your need
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
-    projects: '**/*.csproj'
+    projects: 'apis/**/**/UnitTests.csproj' # This works
+    #projects: 'apis/**/tests/**/*.csproj' # One test fails with this.
     arguments: '--configuration $(buildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: publish
-    arguments: '--configuration Release --output $(build.artifactStagingDirectory)/publish_output'
-    projects: '**/*.csproj'
-    publishWebProjects: false
-    modifyOutputPath: true
-    zipAfterPublish: false
-
-- task: ArchiveFiles@2
-  displayName: "Archive files"
-  inputs:
-    rootFolderOrFile: "$(build.artifactStagingDirectory)/publish_output/"
-    includeRootFolder: false
-    archiveFile: "$(build.artifactStagingDirectory)/WebApp.zip"
+# Tasks to publish, archive files and publish the artifacts:
+#- task: DotNetCoreCLI@2
+#  inputs:
+#    command: publish
+#    arguments: '--configuration Release --output $(build.artifactStagingDirectory)/publish_output'
+#    projects: 'apis/**/web/*.csproj'
+#    publishWebProjects: false
+#    modifyOutputPath: true
+#    zipAfterPublish: false
+#
+#- task: ArchiveFiles@2
+#  displayName: "Archive files"
+#  inputs:
+#    rootFolderOrFile: "$(build.artifactStagingDirectory)/publish_output/"
+#    includeRootFolder: false
+#    archiveFile: "$(build.artifactStagingDirectory)/WebApp.zip"
 #- task: PublishBuildArtifacts@1
 #  inputs:
 #    PathtoPublish: '$(build.artifactStagingDirectory)/WebApp.zip'
 #    artifactName: 'WebApp'
+
+# This only works on Windows: (But it has a lot of information out of the box!)
+# For more information go to:
+# https://marketplace.visualstudio.com/items?itemName=AmanBedi18.CreateBugTask
+#- task: CreateBug@2
+#  inputs:
+#    isyamlpipeline: true
+#    custompaths: false
+#    customrequestor: false
+#  condition: failed()
+#  env:
+#    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+# Create or update a work item: (Might need more details on the body)
+# For more information go to:
+# https://marketplace.visualstudio.com/items?itemName=mspremier.CreateWorkItem
+- task: CreateWorkItem@1
+  displayName: 'Create Bug on Failure'
+  inputs:
+    workItemType: bug
+    iterationPath: '@CurrentIteration'
+    title: Azure Pipeline $(Build.DefinitionName) failed against build $(Build.BuildNumber)
+  condition: failed()


### PR DESCRIPTION
This PR updates the ADO pipeline so it only gets triggered on a PR to the main branch in the path for apis/poi. It also includes a task that creates a bug in the current iteration when the build or the tests fail.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Updates pipeline so it only gets triggered on PRs
* Creates a bug in ADO boards when the build or the tests fail.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Create a PR with changes outside of apis/poi. This shouldn't trigger the pipeline
* Create a PR with changes inside of apis/poi. This should trigger the pipeline
* Create a PR that breaks the build by commenting something out. This should trigger the pipeline and create a bug in ADO.