### PR TITLE
Updated pipelines to remove start-up commands

### DIFF
--- a/.github/workflows/trips-cd.yml
+++ b/.github/workflows/trips-cd.yml
@@ -76,6 +76,5 @@ jobs:
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} 
         images: ${{ env.ACRNAME }}/devopsoh/api-trips:${{ env.BASEIMAGETAG }}
-        startup-command: 'go run main.go'    # Include start up command to start the app container
         slot-name: staging
   

--- a/.github/workflows/userprofile-cd.yml
+++ b/.github/workflows/userprofile-cd.yml
@@ -78,5 +78,5 @@ jobs:
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} 
         images: ${{ env.ACRNAME }}/${{ env.ACR_REPOSITORY }}:${{ env.BASEIMAGETAG }}
-        startup-command: 'npm start'    # Include start up command to start the app container
+        # startup-command: 'npm start'    # Include start up command to start the app container
   


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove trips' pipeline startup command to fix the App Service
* Remove userprofile's pipeline startup command

The startup command was causing the trips API to fail when accessed through the correct URI. Accessing the health check URIs through the trip-viewer application yields the incorrect URLs.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Navigate to [the trip's API health check in the staging slot](https://openhackyvs74zq0trips-staging.azurewebsites.net/api/healthcheck/trips), this should yield a response instead of timing out.
* Navigate to [the user profile's API health check in the production slot](https://openhackyvs74zq0userprofile.azurewebsites.net/api/healthcheck/user), this should yield a response instead of timing out.
* Navigate to [the user-java's API health check in the staging slot](https://openhackyvs74zq0userjava-staging.azurewebsites.net/api/healthcheck/user-java), this should yield a response instead of timing out.
